### PR TITLE
Fail if pgsql returned row is bigger than limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ node_js:
   - "0.10"
 before_script:
   - node script/create-test-tables.js pg://postgres@127.0.0.1:5432/postgres
+env:
+  - PGUSER=postgres PGDATABASE=postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 0.8
   - "0.10"
 before_script:
   - node script/create-test-tables.js pg://postgres@127.0.0.1:5432/postgres

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,6 @@ test: test-unit
 
 test-all: jshint test-unit test-integration test-native test-binary
 
-test-travis: test-all upgrade-pg
-	@make test-all connectionString=postgres://postgres@localhost:5433/postgres
-
 upgrade-pg:
 	@chmod 755 script/travis-pg-9.2-install.sh
 	@./script/travis-pg-9.2-install.sh

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -4,6 +4,7 @@ var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 
 var utils = require(__dirname + '/utils');
+var defaults = require(__dirname + '/defaults');
 var Writer = require('buffer-writer');
 
 var TEXT_MODE = 0;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -347,6 +347,12 @@ Connection.prototype.parseMessage =  function() {
   //read message length
   var length = this.parseInt32(buffer);
 
+  if (id == 0x44 && buffer.length > defaults.maxRowSize) {
+    this.stream.emit('error', new Error('Row too large: ' + buffer.length));
+    this.stream.emit('end');
+    return ("Row too large: " + buffer.length);
+  }
+
   if(remaining <= length) {
     this.lastBuffer = this.buffer;
     //rewind the last 5 bytes we read

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -348,10 +348,12 @@ Connection.prototype.parseMessage =  function() {
   //read message length
   var length = this.parseInt32(buffer);
 
-  if (id == 0x44 && buffer.length > defaults.maxRowSize) {
-    this.stream.emit('error', new Error('Row too large: ' + buffer.length));
-    this.stream.emit('end');
-    return ("Row too large: " + buffer.length);
+  if (defaults.maxRowSize !== undefined) {
+    if (id == 0x44 && buffer.length > defaults.maxRowSize) {
+      this.stream.emit('error', new Error('Row too large, was ' + buffer.length + ' bytes'));
+      this.stream.emit('end');
+      return false;
+    }
   }
 
   if(remaining <= length) {

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -40,7 +40,7 @@ var defaults = module.exports = {
 
   ssl: false,
 
-  maxRowSize: 2000000
+  maxRowSize: undefined
 };
 
 //parse int8 so you can get your count values as actual numbers

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -38,7 +38,9 @@ var defaults = module.exports = {
 
   client_encoding: "",
 
-  ssl: false
+  ssl: false,
+
+  maxRowSize: 2000000
 };
 
 //parse int8 so you can get your count values as actual numbers

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "semver": "~1.1.4"
   },
   "scripts": {
-    "test": "make test-travis connectionString=postgres://postgres@localhost:5432/postgres",
+    "test": "make test-all connectionString=postgres://postgres@localhost:5432/postgres",
     "install": "node-gyp rebuild || (exit 0)"
   },
   "engines": {

--- a/test/integration/client/error-handling-tests.js
+++ b/test/integration/client/error-handling-tests.js
@@ -1,4 +1,5 @@
 var helper = require(__dirname + '/test-helper');
+var pg = helper.pg;
 var util = require('util');
 
 var createErorrClient = function() {
@@ -179,3 +180,22 @@ test('query receives error on client shutdown', function() {
   }));
 });
 
+test('query adeheres to maxRowSize', function() {
+    var client = new Client(helper.config);
+
+    client.connect(function() {
+        var query = 'SELECT 1 as id',
+            queryRowSize = 60;
+
+        test('too large row', function() {
+            pg.defaults.maxRowSize = queryRowSize - 1;
+            client.query(query, assert.calls(function(err, res) {
+                // relax maxRowSize
+                pg.defaults.maxRowSize = undefined;
+
+                assert(err);
+                assert.equal(err.message, 'Row too large, was ' + queryRowSize + ' bytes');
+            }));
+        });
+    });
+});

--- a/test/integration/client/error-handling-tests.js
+++ b/test/integration/client/error-handling-tests.js
@@ -181,6 +181,11 @@ test('query receives error on client shutdown', function() {
 });
 
 test('query adeheres to maxRowSize', function() {
+    // not implemented in native library, so it does not make sense to run this test in native mode
+    if (helper.config.native) {
+        return true;
+    }
+
     var client = new Client(helper.config);
 
     client.connect(function() {


### PR DESCRIPTION
If a row returned by pgsql stream is bigger than the configured row size
max limit return a error and stop consuming from the stream
