### PR TITLE
[node-v6] Add support to Node v6 LTS

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -153,6 +153,10 @@ Client.prototype.connect = function(callback) {
       self.emit('notification', msg);
     });
 
+    con.on('maxRowSize', function (msg) {
+      self.emit('maxRowSize', msg);
+    });
+    
     //process possible callback argument to Client#connect
     if (callback) {
       callback(null, self);

--- a/lib/client.js
+++ b/lib/client.js
@@ -156,7 +156,7 @@ Client.prototype.connect = function(callback) {
     con.on('maxRowSize', function (msg) {
       self.emit('maxRowSize', msg);
     });
-    
+
     //process possible callback argument to Client#connect
     if (callback) {
       callback(null, self);

--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -59,6 +59,7 @@ var ConnectionParameters = function(config) {
   this.client_encoding = val("client_encoding", config);
   //a domain socket begins with '/'
   this.isDomainSocket = (!(this.host||'').indexOf('/'));
+  this.keepAlive = config.keepAlive || false;
 
   this.application_name = val('application_name', config, 'PGAPPNAME');
   this.fallback_application_name = val('fallback_application_name', config, false);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -10,6 +10,8 @@ var net = require('net');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 
+var defaults = require(__dirname + '/defaults');
+
 var Writer = require('buffer-writer');
 var Reader = require('packet-reader');
 
@@ -521,6 +523,10 @@ var DataRowMessage = function(length, fieldCount) {
 
 //extremely hot-path code
 Connection.prototype.parseD = function(buffer, length) {
+  if (Number.isFinite(defaults.maxRowSize) && length > defaults.maxRowSize) {
+    return new Message('maxRowSize', length);
+  }
+
   var fieldCount = this.parseInt16(buffer);
   var msg = new DataRowMessage(length, fieldCount);
   for(var i = 0; i < fieldCount; i++) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -10,7 +10,7 @@ var net = require('net');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 
-var defaults = require(__dirname + '/defaults');
+var defaults = require('./defaults');
 
 var Writer = require('buffer-writer');
 var Reader = require('packet-reader');

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,10 +1,14 @@
 var ConnectionParameters = require(__dirname + '/../lib/connection-parameters');
 var config = new ConnectionParameters(process.argv[2]);
+var semver = require('semver')
 
 for(var i = 0; i < process.argv.length; i++) {
   switch(process.argv[i].toLowerCase()) {
   case 'native':
-    config.native = true;
+    if (semver.gte(process.version, '4.0.0')) {
+      console.log('Not running native in node < v4.0.0')
+      config.native = true;
+    }
     break;
   case 'binary':
     config.binary = true;

--- a/test/cli.js
+++ b/test/cli.js
@@ -6,8 +6,9 @@ for(var i = 0; i < process.argv.length; i++) {
   switch(process.argv[i].toLowerCase()) {
   case 'native':
     if (semver.gte(process.version, '4.0.0')) {
-      console.log('Not running native in node < v4.0.0')
       config.native = true;
+    } else {
+      console.log('Not running native in node < v4.0.0')
     }
     break;
   case 'binary':


### PR DESCRIPTION
This PR uses the latest version of `node-postgres` with our customizations already applied:
 - Expose keep-alive connection param.
 - Emit `maxRowSize` if the returned row is bigger than limit
 - Avoid running native tests with node < 4.0.0
